### PR TITLE
Proposition for fixing issue #10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ artifacts {
 }
 
 signing {
+	required { gradle.taskGraph.hasTask("uploadArchives") }
 	sign configurations.archives
 }
 

--- a/src/main/java/nl/javadude/scannit/reader/ClasspathReader.java
+++ b/src/main/java/nl/javadude/scannit/reader/ClasspathReader.java
@@ -85,7 +85,11 @@ public class ClasspathReader {
         String path = packagePrefixToPath(prefix);
         for (URI urI : urIs) {
             String schemeSpecificPart = urI.getSchemeSpecificPart();
-            String based = schemeSpecificPart.substring(0, schemeSpecificPart.length() - path.length());
+            int l = path.length();
+            if (schemeSpecificPart.endsWith("/") && !path.endsWith("/")) {
+                l++;
+	        }
+            String based = schemeSpecificPart.substring(0, schemeSpecificPart.length() - l);
             try {
                 result.add(new URI(urI.getScheme(), based, urI.getFragment()));
             } catch (URISyntaxException e) {

--- a/src/test/java/nl/javadude/scannit/reader/ClasspathReaderTest.java
+++ b/src/test/java/nl/javadude/scannit/reader/ClasspathReaderTest.java
@@ -23,7 +23,8 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -92,7 +93,7 @@ public class ClasspathReaderTest {
         @Override
         public Set<URI> findURIs(String packagePrefix) {
             try {
-                return Collections.singleton(new URI(uri));
+             	return new HashSet<URI>(Arrays.asList(new URI(uri), new URI(uri + "/")));
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
After the upgrade of "Overthere" to 4.3.2 which depends of "Scannit" 1.4.0 the opening of a connection throws the following exception : 
`IllegalArgumentException: Unknown connection protocol cifs
        at com.xebialabs.overthere.Overthere.getConnection(Overthere.java:103)
`
The application is deployed in Tomcat 8, this problem is describe in the issue #10.

The method `urI.getSchemeSpecificPart()` returns for example:
        `file:/E:/eclipse-workspaces/mars2/.metadata/.plugins/org.eclipse.wst.server.core/tmp0/wtpwebapps/CARLAdminWar/WEB-INF/lib/overthere-4.3.2-carl-1.jar!/com/xebialabs/`

Since the local variable `path` contains `com/xebialabs`, the `based` variable is invalid (its ended by `!/c`).
